### PR TITLE
Removed Firefox xulrunner force from product build

### DIFF
--- a/products/org.csstudio.iter.css.product/plugin_customization.ini
+++ b/products/org.csstudio.iter.css.product/plugin_customization.ini
@@ -320,9 +320,6 @@ org.python.pydev/CHECK_PREFERRED_PYDEV_SETTINGS=false
 
 org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
 
-# Avoid SIGSEGV when opening Help (eclipse-4.3+)
-org.eclipse.swt.browser.DefaultType=mozilla
-
 org.csstudio.utility.batik/use_cache=true
 
 #

--- a/repository-rcp/org.csstudio.iter.product.css.product
+++ b/repository-rcp/org.csstudio.iter.product.css.product
@@ -25,8 +25,6 @@ openFile
 -Dorg.apache.commons.logging.Log=org.apache.commons.logging.impl.SimpleLog
 -Dorg.apache.commons.logging.simplelog.defaultlog=fatal
 -Dpython.cachedir.skip=true
--Dorg.eclipse.swt.browser.DefaultType=mozilla
--Dorg.eclipse.swt.browser.XULRunnerPath=/usr/lib64/firefox
 -Dorg.osgi.framework.bundle.parent=ext
 -Dosgi.framework.extensions=org.eclipse.fx.osgi
       </vmArgs>


### PR DESCRIPTION
Update to org.csstudio.iter.product.css.product and plugin_customization.ini -- firefix engine was still forced in this files.